### PR TITLE
Reuse precomputed embeddings for side pane sim

### DIFF
--- a/src/VectorServer/index.ts
+++ b/src/VectorServer/index.ts
@@ -49,13 +49,16 @@ export default class VectorServer {
 		);
 	}
 
-	async getSidePaneNoteList(file: TFile) {
-		const content = await this.plugin.app.vault.cachedRead(file);
-		const cleanContent = this.getCleanDoc(content);
+	async getSimilarNotes(file: TFile) {
+		// TODO: Caching!
+		//const content = await this.plugin.app.vault.cachedRead(file);
+		//const cleanContent = this.getCleanDoc(content);
+		const fileVector = await this.weaviateManager.getFileMeanEmbedding(
+			file.path
+		);
 
-		return this.weaviateManager.queryText(
-			cleanContent,
-			[],
+		return this.weaviateManager.queryVector(
+			fileVector,
 			this.plugin.settings.limit,
 			this.plugin.settings.distanceLimit,
 			this.plugin.settings.autoCut

--- a/src/chunks/schema.ts
+++ b/src/chunks/schema.ts
@@ -58,7 +58,16 @@ export function createOpenAIChunkClass(
 		class: className,
 		description: "File chunks from Obsidian vault text files",
 		properties: [
-			newMetadataField("path"),
+			{
+				name: "path",
+				datatype: ["text"],
+				indexFilterable: true,
+				moduleConfig: {
+					["text2vec-openai"]: {
+						skip: "true",
+					},
+				},
+			},
 			{
 				name: "content",
 				datatype: ["text"],

--- a/src/main.ts
+++ b/src/main.ts
@@ -237,7 +237,6 @@ export default class AINoteSuggestionPlugin extends Plugin {
 
 	registerEvents() {
 		// console.log("register events")
-
 		this.app.workspace.onLayoutReady(() =>
 			// Avoid spurious "creation" requests
 			this.registerEvent(


### PR DESCRIPTION
This PR adds:
- Similar notes now uses max pooling of chunks from server instead of re-embedding the whole document each time, reducing cost at the cost of slightly worse performance
- Side pane now allows direct jump to chunk, like modal